### PR TITLE
Fix timezone in temp candle generation

### DIFF
--- a/src/main/java/kim/donghyun/service/CandleService.java
+++ b/src/main/java/kim/donghyun/service/CandleService.java
@@ -197,7 +197,8 @@ public class CandleService {
     
  // ✅ 실시간 임시 15분 캔들 생성
     public CandleDTO generateTemp15MinCandle() {
-        LocalDateTime now = LocalDateTime.now().withSecond(0).withNano(0);
+        // UTC 기준으로 현재 시각 계산
+        LocalDateTime now = LocalDateTime.now(ZoneOffset.UTC).withSecond(0).withNano(0);
         LocalDateTime start = now.minusMinutes(15);
 
         System.out.println("🧪 임시 15분봉 생성 시도: " + start + " ~ " + now);


### PR DESCRIPTION
## Summary
- ensure `generateTemp15MinCandle` uses UTC times

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68400c1d12048327b50a0fef2f95beec